### PR TITLE
Add support for NixOS

### DIFF
--- a/hyprfreeze
+++ b/hyprfreeze
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 PID=$(hyprctl activewindow | grep -i pid | awk -F "pid: " '{ print $2 }' | awk -F "," '{ print $1 }')
 PIDS=$(pstree $PID -npl | grep -oP '(?<=\()[0-9]+(?=\))')


### PR DESCRIPTION
With this change, bash will be called using env. Adding support for non-FHS distros, including NixOS.