### PR TITLE
feat: initial Sway support

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,10 +50,10 @@ bind = , PAUSE, exec, hyprfreeze -a
 ```
 -h, --help            show help message
 
--a, --active          toggle suspend by active window
+-a, --active          toggle suspend by active window (supported on hyprland and sway)
 -p, --pid             toggle suspend by process id
 -n, --name            toggle suspend by process name/command
--r, --prop            toggle suspend by clicking on window (hyprprop must be installed)
+-r, --prop            toggle suspend by clicking on window (supported on hyperland, hyprprop must be installed)
 
 -s, --silent          don't send notification
 -t, --notif-timeout   notification timeout in milliseconds (default 5000)

--- a/README.md
+++ b/README.md
@@ -50,10 +50,10 @@ bind = , PAUSE, exec, hyprfreeze -a
 ```
 -h, --help            show help message
 
--a, --active          toggle suspend by active window (supported on hyprland and sway)
+-a, --active          toggle suspend by active window
 -p, --pid             toggle suspend by process id
 -n, --name            toggle suspend by process name/command
--r, --prop            toggle suspend by clicking on window (supported on hyperland, hyprprop must be installed)
+-r, --prop            toggle suspend by clicking on window (hyprprop/swayprop must be installed)
 
 -s, --silent          don't send notification
 -t, --notif-timeout   notification timeout in milliseconds (default 5000)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # hyprfreeze
 [![basher install](https://www.basher.it/assets/logo/basher_install.svg)](https://www.basher.it/package/)
-Hyprfreeze is a utility to suspend a game process (and other programs) on Wayland
+Hyprfreeze is a utility to suspend a game process (and other programs) in Hyprland and Sway.
 
 https://github.com/Zerodya/hyprfreeze/assets/73220426/541318e2-441a-485a-91c5-f58d4f65926a
 

--- a/README.md
+++ b/README.md
@@ -19,7 +19,6 @@ Hyprfreeze is available in [AUR](https://aur.archlinux.org/packages/hyprfreeze-g
 - a compatible window manager (`hyprland` or `sway`) to get the PID of the active window
 - `jq` to parse json
 - `psmisc` contains 'pstree' which is required to list child processes
-- Systemd for the `loginctl` utility
   ### Optional
 - [`hyprprop`](https://github.com/vilari-mickopf/hyprprop) or [`swayprop`](https://git.alternerd.tv/alterNERDtive/swayprop) to get the pid of a window by selecting it with your mouse
   ### Highly Recommended

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ Hyprfreeze is available in [AUR](https://aur.archlinux.org/packages/hyprfreeze-g
 - a compatible window manager (`hyprland` or `sway`) to get the PID of the active window
 - `jq` to parse json
 - `psmisc` contains 'pstree' which is required to list child processes
+- Systemd for the `loginctl` utility
   ### Optional
 - [`hyprprop`](https://github.com/vilari-mickopf/hyprprop) to get the pid of a window by selecting it with your mouse
   ### Highly Recommended

--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 # hyprfreeze
 [![basher install](https://www.basher.it/assets/logo/basher_install.svg)](https://www.basher.it/package/)
-Hyprfreeze is a utility to suspend a game process (and other programs) in
-Hyprland.
+Hyprfreeze is a utility to suspend a game process (and other programs) on Wayland
 
 https://github.com/Zerodya/hyprfreeze/assets/73220426/541318e2-441a-485a-91c5-f58d4f65926a
 
@@ -17,7 +16,7 @@ https://github.com/Zerodya/hyprfreeze/assets/73220426/541318e2-441a-485a-91c5-f5
 Hyprfreeze is available in [AUR](https://aur.archlinux.org/packages/hyprfreeze-git).
 
 ### Dependencies
-- `hyprland` to get the pid of the active window with hyprctl
+- a compatible window manager (`hyprland` or `sway`) to get the PID of the active window
 - `jq` to parse json
 - `psmisc` contains 'pstree' which is required to list child processes
   ### Optional
@@ -39,7 +38,7 @@ ln -s $(pwd)/Hyprfreeze/hyprfreeze $HOME/.local/bin
 ```
 
 ## Usage
-Add a bind in your Hyprland config to pause the current active window:
+Add a bind in your Hyprland or Sway config to pause the current active window:
 ```bash
 # ~/.config/hypr/hyprland.conf
 ...

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Hyprfreeze is available in [AUR](https://aur.archlinux.org/packages/hyprfreeze-g
 - `psmisc` contains 'pstree' which is required to list child processes
 - Systemd for the `loginctl` utility
   ### Optional
-- [`hyprprop`](https://github.com/vilari-mickopf/hyprprop) to get the pid of a window by selecting it with your mouse
+- [`hyprprop`](https://github.com/vilari-mickopf/hyprprop) or [`swayprop`](https://git.alternerd.tv/alterNERDtive/swayprop) to get the pid of a window by selecting it with your mouse
   ### Highly Recommended
 - [`gamescope`](https://github.com/ValveSoftware/gamescope) fixes mouse input not working in other XWayland windows after pausing a Wine game. It's also the superior way to game in Wayland anyway.
 

--- a/hyprfreeze
+++ b/hyprfreeze
@@ -122,12 +122,9 @@ function getPidByProp() {
 }
 
 function detectEnvironment() {
-  local Type
   local Desktop
-  eval "$(loginctl show-session $(loginctl | grep $(whoami) | awk '{print $1}') -p Type -p Desktop)"
-  [ -z "$Type" ] && echo "Could not determine session type via \`loginctl\`." && exit 1
-  [ -z "$Desktop" ] && echo "Could not determine desktop environment via \`loginctl\`." && exit 1
-  SESSION=$Type
+  eval "$(loginctl show-session $(loginctl | grep $(whoami) | awk '{print $1}') -p Desktop)"
+  [ -z "$Desktop" ] && echo "Could not determine desktop environment via \`loginctl\`. Assuming Hyprland." && Desktop="hyprland"
   DESKTOP=$Desktop
 }
 

--- a/hyprfreeze
+++ b/hyprfreeze
@@ -135,14 +135,11 @@ function detectEnvironment() {
     debugPrint "Could not determine desktop environment via \`loginctl\`, and `$XDG_DESKTOP_SESSION` is not set. Assuming Hyprland."
     DESKTOP="hyprland"
   fi
+
+  debugPrint "Desktop: $DESKTOP"
 }
 
 function printInfo() {
-  debugPrint "Printing environment info..."
-  echo -e "$(tput bold)Session type:$(tput sgr0) $SESSION"
-  echo -e "$(tput bold)Desktop:$(tput sgr0) $DESKTOP"
-  echo ""
-
   debugPrint "Printing process info..."
   echo -e "$(tput bold)Process tree:$(tput sgr0)"
   ps -p "$PID" 2>/dev/null && pstree -p "$PID"

--- a/hyprfreeze
+++ b/hyprfreeze
@@ -9,10 +9,10 @@ Utility to suspend a game process (and other programs) in Hyprland.
 Options:
   -h, --help            show help message
 
-  -a, --active          toggle suspend by active window
+  -a, --active          toggle suspend by active window (supported on hyprland and sway)
   -p, --pid             toggle suspend by process id
   -n, --name            toggle suspend by process name/command
-  -r, --prop            toggle suspend by clicking on window (hyprprop must be installed)
+  -r, --prop            toggle suspend by clicking on window (supported on hyprland, hyprprop must be installed)
 
   -s, --silent          don't send notification
   -t, --notif-timeout   notification timeout in milliseconds (default 5000)

--- a/hyprfreeze
+++ b/hyprfreeze
@@ -12,7 +12,8 @@ Options:
   -a, --active          toggle suspend by active window (supported on hyprland and sway)
   -p, --pid             toggle suspend by process id
   -n, --name            toggle suspend by process name/command
-  -r, --prop            toggle suspend by clicking on window (supported on hyprland, hyprprop must be installed)
+  -r, --prop            toggle suspend by clicking on window (supported on hyprland and sway,
+                        hyprprop/swayprop must be installed)
 
   -s, --silent          don't send notification
   -t, --notif-timeout   notification timeout in milliseconds (default 5000)
@@ -100,12 +101,19 @@ function getPidByName() {
 function getPidByProp() {
   debugPrint "Getting PID by prop..."
   if [[ "hyprland" == "$DESKTOP" ]]; then
-    if ! command -v hyprprop; then
+    if ! [ $(command -v hyprprop) ]; then
       echo "You need to install 'hyprprop' to use this feature. (https://github.com/vilari-mickopf/hyprprop)"
       exit 1
     fi
 
     PID=$(hyprprop | jq '.pid')
+  elif [[ "sway" == "$DESKTOP" ]]; then
+    if ! [ $(command -v swayprop) ]; then
+      echo "You need to install 'swayprop' to use this feature. (https://git.alternerd.tv/alterNERDtive/swayprop)"
+      exit 1
+    fi
+
+    PID=$(swayprop | jq '.pid')
   else
     echo "Selecting the target window by mouse is currently not supported on $DESKTOP."
     exit 1

--- a/hyprfreeze
+++ b/hyprfreeze
@@ -101,8 +101,23 @@ function getPidByProp() {
   debugPrint "PID by prop: $PID"
 }
 
+function detectEnvironment() {
+  local Type
+  local Desktop
+  eval "$(loginctl show-session $(loginctl | grep $(whoami) | awk '{print $1}') -p Type -p Desktop)"
+  [ -z "$Type" ] && echo "Could not determine session type via \`loginctl\`." && exit 1
+  [ -z "$Desktop" ] && echo "Could not determine desktop environment via \`loginctl\`." && exit 1
+  SESSION=$Type
+  DESKTOP=$Desktop
+}
+
 function printInfo() {
-  debugPrint "Printing process info...\n"
+  debugPrint "Printing environment info..."
+  echo -e "$(tput bold)Session type:$(tput sgr0) $SESSION"
+  echo -e "$(tput bold)Desktop:$(tput sgr0) $DESKTOP"
+  echo ""
+
+  debugPrint "Printing process info..."
   echo -e "$(tput bold)Process tree:$(tput sgr0)"
   ps -p "$PID" 2>/dev/null && pstree -p "$PID"
 
@@ -225,5 +240,7 @@ DRYRUN=0
 DEBUG=0
 
 args "$@"
+
+detectEnvironment
 
 main

--- a/hyprfreeze
+++ b/hyprfreeze
@@ -56,7 +56,14 @@ function toggleFreeze() {
 
 function getPidByActive() {
   debugPrint "Getting PID by active window..."
-  PID=$(hyprctl activewindow -j | jq '.pid')
+  if [[ "hyprland" == "$DESKTOP" ]]; then
+    PID=$(hyprctl activewindow -j | jq '.pid')
+  elif [[ "sway" == "$DESKTOP" ]]; then
+    PID=$(swaymsg -t get_tree | jq '.. | select(.type?) | select(.focused==true) | .pid')
+  else
+    echo "Detecting the active window is currently not supported on $DESKTOP."
+    exit 1
+  fi
   debugPrint "PID by active window: $PID"
 
   # Die if PID is not numeric (e.g. "null" if there is no active window)

--- a/hyprfreeze
+++ b/hyprfreeze
@@ -9,11 +9,10 @@ Utility to suspend a game process (and other programs) in Hyprland.
 Options:
   -h, --help            show help message
 
-  -a, --active          toggle suspend by active window (supported on hyprland and sway)
+  -a, --active          toggle suspend by active window
   -p, --pid             toggle suspend by process id
   -n, --name            toggle suspend by process name/command
-  -r, --prop            toggle suspend by clicking on window (supported on hyprland and sway,
-                        hyprprop/swayprop must be installed)
+  -r, --prop            toggle suspend by clicking on window (hyprprop/swayprop must be installed)
 
   -s, --silent          don't send notification
   -t, --notif-timeout   notification timeout in milliseconds (default 5000)

--- a/hyprfreeze
+++ b/hyprfreeze
@@ -121,10 +121,20 @@ function getPidByProp() {
 }
 
 function detectEnvironment() {
-  local Desktop
-  eval "$(loginctl show-session $(loginctl | grep $(whoami) | awk '{print $1}') -p Desktop)"
-  [ -z "$Desktop" ] && echo "Could not determine desktop environment via \`loginctl\`. Assuming Hyprland." && Desktop="hyprland"
-  DESKTOP=$Desktop
+  if [ $(command -v loginctl) ]; then
+    local Desktop
+    eval "$(loginctl show-session $(loginctl | grep $(whoami) | awk '{print $1}') -p Desktop)"
+    DESKTOP=$Desktop
+  fi
+
+  if [ -z "$DESKTOP" ]; then
+    DESKTOP=$XDG_SESSION_DESKTOP
+  fi
+
+  if [ -z "$DESKTOP" ]; then
+    debugPrint "Could not determine desktop environment via \`loginctl\`, and `$XDG_DESKTOP_SESSION` is not set. Assuming Hyprland."
+    DESKTOP="hyprland"
+  fi
 }
 
 function printInfo() {

--- a/hyprfreeze
+++ b/hyprfreeze
@@ -99,12 +99,17 @@ function getPidByName() {
 
 function getPidByProp() {
   debugPrint "Getting PID by prop..."
-  if ! command -v hyprprop; then
-    echo "You need to install 'hyprprop' to use this feature. (https://github.com/vilari-mickopf/hyprprop)"
+  if [[ "hyprland" == "$DESKTOP" ]]; then
+    if ! command -v hyprprop; then
+      echo "You need to install 'hyprprop' to use this feature. (https://github.com/vilari-mickopf/hyprprop)"
+      exit 1
+    fi
+
+    PID=$(hyprprop | jq '.pid')
+  else
+    echo "Selecting the target window by mouse is currently not supported on $DESKTOP."
     exit 1
   fi
-
-  PID=$(hyprprop | jq '.pid')
   debugPrint "PID by prop: $PID"
 }
 


### PR DESCRIPTION
Adds support for Sway; at least for freezing the _active window_. AFAIK there’s no utility like `hyprprop` for Sway. The detection logic relies on `loginctl` which is part of Systemd. If you’re not OK with that dependency, I’ll have to go an uglier route :)

Will output an error message if a command is run under a window manager that does not support it. As a side effect will also produce error messages if you are running it under a completely different window manager. WM-agnostig commands (like freezing by name or by PID) will still work anywhere.

Currently it will die if no information can be obtained from `loginctl`. If you prefer to silently assume Wayland/Hyprland, that’s trivial to implement.

Session/Desktop information added to `printInfo` as well.

Can you double check the output of `loginctl show-session $(loginctl | grep $(whoami) | awk '{print $1}') -p Type -p Desktop` on Hyprland for me, please? Also on any other DE/WM if you happen to have easy access to more of them, for reference.