### PR TITLE
fix: check for numeric PID in `getPidByActive`

### DIFF
--- a/hyprfreeze
+++ b/hyprfreeze
@@ -58,6 +58,12 @@ function getPidByActive() {
   debugPrint "Getting PID by active window..."
   PID=$(hyprctl activewindow -j | jq '.pid')
   debugPrint "PID by active window: $PID"
+
+  # Die if PID is not numeric (e.g. "null" if there is no active window)
+  if ! [[ $PID == ?(-)+([[:digit:]]) ]]; then
+    echo "Cannot freeze window with invalid PID $PID."
+    exit 1
+  fi
 }
 
 function getPidByPid() {


### PR DESCRIPTION
At least the Sway method of getting the active window returns `null` if there is no active window. You will have to check hyprland behaviour yourself :)

I put the condition in `toggleFreeze` so it can catch _any_ case of borked PID. Arguably each method of getting a PID should have their own set of checks, as `getPidByPid` already has. I will leave it up to you if you accept this as-is or want me to move it over to `getPidByActive` (in which case `getPidByProp` probably needs a similar check).