### PR TITLE
fix: enforce lowercase to fix `hyprland` detection

### DIFF
--- a/hyprfreeze
+++ b/hyprfreeze
@@ -136,6 +136,9 @@ function detectEnvironment() {
     DESKTOP="hyprland"
   fi
 
+  # Enforce lowercase for consistent matching
+  DESKTOP="${DESKTOP,,}"
+
   debugPrint "Desktop: $DESKTOP"
 }
 


### PR DESCRIPTION
Hey just a small PR. This is to fix `hyprland` detection, because as recommended [here in the docs](https://wiki.hyprland.org/Configuring/Environment-variables/), I have `XDG_SESSION_DESKTOP=Hyprland` (uppercase H).

This change just makes sure `DESKTOP` is all lowercase so it also won't break for anyone using `hyprland`. This does assume Bash version > 4.0 (2009), but if you want I could just use something like this instead:

```bash
DESKTOP="$(echo "$DESKTOP" | tr 'H' 'h')"
```