### PR TITLE
Update AUR package link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ If your compositor is not supported yet, please consider [opening an issue](http
 
 ## Installation
 ### Arch Linux
-Available in the [AUR](https://aur.archlinux.org/packages/hyprfreeze-git). (Maintained by [Aethar](https://github.com/Aethar01)) **(update pending)**
+Available in the [AUR](https://aur.archlinux.org/packages/wl-freeze-git). (Maintained by [Aethar](https://github.com/Aethar01))
 
 ### NixOS
 Available in [nixpkgs](https://search.nixos.org/packages?channel=unstable&query=hyprfreeze).  **(update pending)**


### PR DESCRIPTION
Updated AUR package link from 'hyprfreeze-git' to 'wl-freeze-git'.