### PR TITLE
Also check $XDG_CURRENT_DESKTOP

### DIFF
--- a/wl-freeze
+++ b/wl-freeze
@@ -71,6 +71,10 @@ function detectCompositor() {
   if [[ -z "$DESKTOP" ]]; then
     DESKTOP="${XDG_SESSION_DESKTOP:-}"
   fi
+  
+  if [[ -z "$DESKTOP" ]]; then
+    DESKTOP="${XDG_CURRENT_DESKTOP:-}"
+  fi
 
   # Normalize
   DESKTOP="${DESKTOP,,}"


### PR DESCRIPTION
On my system, $XDG_SESSION_DESKTOP and loginctl gives empty output and fails to detect compositor. Checking also for $XDG_CURRENT_DESKTOP worked. Feel free to make adjustments.