### PR TITLE
Add support for KWin (kde)

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ https://github.com/user-attachments/assets/7ffdfde5-2028-4936-b61c-092b2cf224c3
 - **Hyprland**
 - **Sway**
 - **Niri**
+- **KWin (kde)**
 
 ### Unsupported compositors
 
@@ -45,6 +46,7 @@ Available in [nixpkgs](https://search.nixos.org/packages?channel=unstable&query=
 - `psmisc` contains `pstree` which is required to list child processes
 - `xdotool` to find the PID of XWayland windows created via `xwayland-satellite` (Mainly for **Niri**)
 - `libnotify` for desktop notifications (Optional)
+- `kdotool` for KWin support (Optional)
 
 **Symlink script**
 

--- a/run-kde.sh
+++ b/run-kde.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+
+set -uo pipefail
+wl-freeze -a

--- a/run-kde.sh
+++ b/run-kde.sh
@@ -1,4 +1,0 @@
-#!/usr/bin/env bash
-
-set -uo pipefail
-wl-freeze -a

--- a/wl-freeze
+++ b/wl-freeze
@@ -105,8 +105,11 @@ function isXWaylandWindow() {
       fi
       ;;
     kde|plasma)
-      # TODO: Determine if KDE needs this workaround
-      result="false"
+      if command -v xdotool >/dev/null 2>&1; then
+        if xdotool getactivewindow >/dev/null 2>&1; then
+          result="true"
+        fi
+      fi
       ;;
     sway)
       # TODO: Determine if Sway needs this workaround
@@ -162,7 +165,26 @@ function releaseMouseCapture() {
       fi
       ;;
     kde|plasma)
-      debugPrint "kde - no XWayland mouse capture release implemented"
+      local qdbus
+      for qdbus in qdbus6 qdbus-qt6 qdbus; do command -v "$qdbus" >/dev/null 2>&1 && break; done
+      [[ -n "$qdbus" ]] || { debugPrint "No qdbus found"; return 1; }
+
+      # Unfullscreen first since Plasma glitches when switching to a frozen fullscreen game
+      local f=$(mktemp --suffix=.js) id
+      printf 'workspace.activeWindow.fullScreen = false;\n' > "$f"
+      id=$($qdbus org.kde.KWin /Scripting org.kde.kwin.Scripting.loadScript "$f" "wlf_$$" 2>/dev/null) &&
+        $qdbus org.kde.KWin "/Scripting/Script$id" org.kde.kwin.Script.run >/dev/null 2>&1
+      rm -f "$f"
+
+      local cur=$($qdbus org.kde.KWin /KWin org.kde.KWin.currentDesktop 2>/dev/null)
+      [[ -n "$cur" ]] || { debugPrint "No current desktop"; return 1; }
+
+      $qdbus org.kde.KWin /KWin org.kde.KWin.nextDesktop >/dev/null
+      local nxt=$($qdbus org.kde.KWin /KWin org.kde.KWin.currentDesktop 2>/dev/null)
+      [[ "$nxt" != "$cur" ]] || { debugPrint "No other workspace"; return 1; }
+
+      debugPrint "Switching workspace $cur -> $nxt -> $cur"
+      $qdbus org.kde.KWin /KWin org.kde.KWin.previousDesktop >/dev/null
       ;;
     sway)
       debugPrint "Sway - no XWayland mouse capture release implemented"

--- a/wl-freeze
+++ b/wl-freeze
@@ -38,7 +38,7 @@ Usage: wl-freeze (-a | -p <pid> | -n <name> | -c <command>) [options]
 
 Utility to suspend a game process (and other programs) in Wayland compositors.
 
-Supported compositors: hyprland, sway, niri
+Supported compositors: hyprland, sway, niri, KWin (kde)
 
 Options:
   -h, --help            show help message
@@ -104,6 +104,10 @@ function isXWaylandWindow() {
         fi
       fi
       ;;
+    kde)
+      window=$(kdotool getactivewindow)
+      kdotool getwindowclassname "$window" >/dev/null 2>&1 && result="true" || result="false"
+      ;;
     sway)
       # TODO: Determine if Sway needs this workaround
       result="false"
@@ -157,7 +161,9 @@ function releaseMouseCapture() {
         niri msg action focus-workspace-up
       fi
       ;;
-
+    kde)
+      debugPrint "kde - no XWayland mouse capture release implemented"
+      ;;
     sway)
       debugPrint "Sway - no XWayland mouse capture release implemented"
       ;;
@@ -181,6 +187,10 @@ function getPidByActive() {
 
     sway)
       PID=$(swaymsg -t get_tree | jq '.. | select(.type?) | select(.focused==true) | .pid')
+      ;;
+
+    kde)
+      PID=$(kdotool getactivewindow getwindowpid)
       ;;
 
     niri)

--- a/wl-freeze
+++ b/wl-freeze
@@ -106,7 +106,7 @@ function isXWaylandWindow() {
       ;;
     kde|plasma)
       if command -v xdotool >/dev/null 2>&1; then
-        if xdotool getactivewindow >/dev/null 2>&1; then
+        if xdotool getactivewindow getwindowpid >/dev/null 2>&1; then
           result="true"
         fi
       fi

--- a/wl-freeze
+++ b/wl-freeze
@@ -104,7 +104,7 @@ function isXWaylandWindow() {
         fi
       fi
       ;;
-    kde)
+    kde|plasma)
       # TODO: Determine if KDE needs this workaround
       result="false"
       ;;
@@ -161,7 +161,7 @@ function releaseMouseCapture() {
         niri msg action focus-workspace-up
       fi
       ;;
-    kde)
+    kde|plasma)
       debugPrint "kde - no XWayland mouse capture release implemented"
       ;;
     sway)
@@ -189,7 +189,7 @@ function getPidByActive() {
       PID=$(swaymsg -t get_tree | jq '.. | select(.type?) | select(.focused==true) | .pid')
       ;;
 
-    kde)
+    kde|plasma)
       PID=$(kdotool getactivewindow getwindowpid)
       ;;
 

--- a/wl-freeze
+++ b/wl-freeze
@@ -105,8 +105,8 @@ function isXWaylandWindow() {
       fi
       ;;
     kde)
-      window=$(kdotool getactivewindow)
-      kdotool getwindowclassname "$window" >/dev/null 2>&1 && result="true" || result="false"
+      # TODO: Determine if KDE needs this workaround
+      result="false"
       ;;
     sway)
       # TODO: Determine if Sway needs this workaround


### PR DESCRIPTION
This PR adds support for KWin on kde as compositor. Because of limitation of keyboard shortcut in kde (or because I am doing something wrong), I added script (run-kde.sh) that launches wl-freeze. This also needs kdotool to be installed. Feel free to make adjustments.